### PR TITLE
This change properly parses Big Endian signals

### DIFF
--- a/src/core/CanDbSignal.cpp
+++ b/src/core/CanDbSignal.cpp
@@ -209,7 +209,7 @@ void CanDbSignal::setMuxValue(const uint32_t &muxValue)
 
 bool CanDbSignal::isPresentInMessage(const CanMessage &msg)
 {
-    if ((_startBit + _length)>(8*msg.getLength())) {
+    if ((_startBit + _length)>(8*msg.getLength()) && !_isBigEndian) {
         return false;
     }
 

--- a/src/parser/dbc/DbcParser.cpp
+++ b/src/parser/dbc/DbcParser.cpp
@@ -552,21 +552,6 @@ bool DbcParser::parseSectionBoSg(CanDb &candb, CanDbMessage *msg, DbcTokenList &
     if (!expectInt(tokens, &byte_order)) { return false; }
     signal->setIsBigEndian(byte_order==0);
 
-    // If the signal is big endian, convert the start bit to the Intel-style start bit for further parsing
-    if(signal->isBigEndian())
-    {
-        // This will be the number of 8-bit rows above the message
-        uint8_t row_position = signal->startBit() >> 3;
-
-        // Bit position in current row (0-7)
-        uint8_t column_position = signal->startBit() & 0b111;
-
-        // Calcualte the normalized start bit position (bit index starting at 0)
-        uint8_t normalized_position = (row_position * 8) + (7 - column_position);
-
-        signal->setStartBit(normalized_position);
-    }
-
     if (expectAndSkipToken(tokens, dbc_tok_plus)) {
         signal->setUnsigned(true);
     } else {


### PR DESCRIPTION
I didn't look into or change anything relating to little endian parsing, but I've tested this change with Big Endian signals in a DBC and it works now