### PR TITLE
DBC parser improvements

### DIFF
--- a/src/parser/dbc/DbcParser.cpp
+++ b/src/parser/dbc/DbcParser.cpp
@@ -265,13 +265,17 @@ bool DbcParser::expectIdentifier(DbcParser::DbcTokenList &tokens, QString *id, b
 bool DbcParser::expectString(DbcParser::DbcTokenList &tokens, QString *str, bool skipWhitespace)
 {
     QString quotedStr;
-    bool ok = expectData(tokens, dbc_tok_string, &quotedStr, skipWhitespace);
-    if (ok && quotedStr.length()>=2) {
-        *str = quotedStr.mid(1, quotedStr.length()-2);
-        return true;
-    } else {
-        return false;
+    if (expectData(tokens, dbc_tok_string, &quotedStr, skipWhitespace)) {
+        // Remove any escape characters
+        quotedStr.replace(QRegExp("\\\\(.)"), "\\1");
+
+        // Remove leading and trailing quotes
+        if (quotedStr.length() >=2 ) {
+            *str = quotedStr.mid(1, quotedStr.length()-2);
+            return true;
+        }
     }
+    return false;
 }
 
 bool DbcParser::expectNumber(DbcParser::DbcTokenList &tokens, QString *str, bool skipWhitespace)

--- a/src/parser/dbc/DbcParser.cpp
+++ b/src/parser/dbc/DbcParser.cpp
@@ -51,7 +51,7 @@ bool DbcParser::parseFile(QFile *file, CanDb &candb)
 
 DbcToken *DbcParser::createNewToken(QChar ch, int line, int column)
 {
-    static const QString acceptableIdStartChars("ABCDEFGHIKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_");
+    static const QString acceptableIdStartChars("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_");
     static const QRegExp numberRegExp("^(\\d+(\\.\\d*)?(E[-+]?\\d*)?)$");
 
     if (ch.isSpace()) {

--- a/src/parser/dbc/DbcTokens.cpp
+++ b/src/parser/dbc/DbcTokens.cpp
@@ -84,19 +84,36 @@ bool DbcIdentifierToken::acceptsChar(QChar ch)
 
 
 DbcStringToken::DbcStringToken(int line, int column)
-  : DbcToken(line, column, dbc_tok_string)
+  : DbcToken(line, column, dbc_tok_string),
+  _done(false),
+  _escape(false)
 {
 }
 
+/// Accept strings surrounded by '"", including '\'-escaped characters
 bool DbcStringToken::acceptsChar(QChar ch)
 {
-   if (_data.isEmpty()) {
-       return (ch=='"');
-   } else if (_data.length()<2) {
-       return true;
-   } else {
-       return !_data.endsWith('"');
-   }
+    if (_done) {
+        return false;
+    }
+
+    if(_data.isEmpty()) {
+        // Start of string must be '"'
+        return (ch == '"');
+    } else {
+        // Accept anything until an unescaped '"'
+        if (_escape) {
+            _escape = false;
+        } else {
+            if (ch == '\\') {
+                _escape = true;
+            }
+            if (ch == '"') {
+                _done = true;
+            }
+        }
+        return true;
+    }
 }
 
 

--- a/src/parser/dbc/DbcTokens.h
+++ b/src/parser/dbc/DbcTokens.h
@@ -83,6 +83,9 @@ class DbcStringToken : public DbcToken {
 public:
     DbcStringToken(int line, int column);
     virtual bool acceptsChar(QChar ch);
+private:
+    bool _done;
+    bool _escape;
 };
 
 class DbcRegExpToken : public DbcToken {


### PR DESCRIPTION
This has two fixes, to enable canable to work with the Nissan Leaf DBC files [published here](https://github.com/dalathegreat/leaf_can_bus_messages).

1. Tokens weren't allowed to start with 'J' - I have not checked the DBC spec but assume that was a simple typo.
2. String type tokens can now include internal double-quote characters, escaped like `\"`.