### PR TITLE
fix: change sorting between aggregate and linear view

### DIFF
--- a/src/window/TraceWindow/TraceWindow.cpp
+++ b/src/window/TraceWindow/TraceWindow.cpp
@@ -96,10 +96,17 @@ void TraceWindow::setMode(TraceWindow::mode_t mode)
     if (_mode==mode_linear) {
         ui->tree->setSortingEnabled(false);
         ui->tree->setModel(_linFilteredModel); //_linearTraceViewModel);
+        if (_timestampMode != timestamp_mode_delta) {
+            ui->tree->sortByColumn(BaseTraceViewModel::column_timestamp, Qt::AscendingOrder);
+        }
+        else {
+            ui->tree->sortByColumn(BaseTraceViewModel::column_canid, Qt::AscendingOrder);
+        }
         ui->cbAutoScroll->setEnabled(true);
     } else {
         ui->tree->setSortingEnabled(true);
         ui->tree->setModel(_aggFilteredModel); //_aggregatedProxyModel);
+        ui->tree->sortByColumn(BaseTraceViewModel::column_canid, Qt::AscendingOrder);
         ui->cbAutoScroll->setEnabled(false);
     }
 
@@ -132,6 +139,14 @@ void TraceWindow::setTimestampMode(int mode)
 
     if (new_mode != _timestampMode) {
         _timestampMode = new_mode;
+
+        if (_mode==mode_linear && _timestampMode != timestamp_mode_delta) {
+            ui->tree->sortByColumn(BaseTraceViewModel::column_timestamp, Qt::AscendingOrder);
+        }
+        else {
+            ui->tree->sortByColumn(BaseTraceViewModel::column_canid, Qt::AscendingOrder);
+        }
+
         for (int i=0; i<ui->cbTimestampMode->count(); i++) {
             if (ui->cbTimestampMode->itemData(i).toInt() == new_mode) {
                 ui->cbTimestampMode->setCurrentIndex(i);
@@ -176,7 +191,7 @@ bool TraceWindow::loadXML(Backend &backend, QDomElement &el)
 
     QDomElement elAggregated = el.firstChildElement("AggregatedTraceView");
     int sortColumn = elAggregated.attribute("SortColumn", "-1").toInt();
-    ui->tree->sortByColumn(sortColumn);
+    ui->tree->sortByColumn(sortColumn, Qt::AscendingOrder);
 
     return true;
 }


### PR DESCRIPTION
This PR sets the sorting in "linear-mode" to the timestamp column instead of the  CAN-ID as for aggregate mode